### PR TITLE
add missing property for clone node

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2407,6 +2407,7 @@ var formNode = function () {
  */
 formNode.prototype.clone = function (parentNode) {
   var node = new formNode();
+  node.childPos = this.childPos;
   node.arrayPath = _.clone(this.arrayPath);
   node.ownerTree = this.ownerTree;
   node.parentNode = parentNode || this.parentNode;


### PR DESCRIPTION
forgot clone ’childPos’ property during clone node
