### PR TITLE
Fix for Browserify / similar require

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -26,7 +26,7 @@
 
 (function(serverside, global, $, _, JSON) {
   // Don't try to load underscore.js if is already loaded
-  if (serverside && typeof _ === 'undefined') {
+  if (serverside && _ === null) {
     _ = require('underscore');
     if (_ === 'undefined') throw 'Failed to load underscore.js';
   }

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -26,9 +26,8 @@
 
 (function(serverside, global, $, _, JSON) {
   // Don't try to load underscore.js if is already loaded
-  if (serverside && _ === null) {
+  if (serverside && !_) {
     _ = require('underscore');
-    if (_ === 'undefined') throw 'Failed to load underscore.js';
   }
 
   var getDefaultClasses = function(isBootstrap2) {


### PR DESCRIPTION
Hi @ulion! Looking at this I don't know if it has been working properly since 2012. Anyways, this seems to fix it for me and the module works with browserify now (if you leak jquery to the global scope [like so](https://github.com/craigmichaelmartin/weather-app--birch/blob/4d9f3b03719e0a2ea3fb5ddbbfc453a10e9843c6/javascript/util/leak_jquery.js)):

since underscore is explicitly defined as null if it is undefined, we should check for whether it is null rather than if it is undefined again.

For context, please see: https://github.com/ulion/jsonform/blob/e590a02ce6729458fdb564da065e2095c923531e/lib/jsonform.js#L4472

Thanks!
