### PR TITLE
Fixed bug with generic (non-submit) buttons.

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1605,7 +1605,7 @@ jsonform.elementTypes = {
     'template':'<input type="submit" <% if (id) { %> id="<%= id %>" <% } %> class="btn btn-primary <%= elt.htmlClass?elt.htmlClass:"" %>" value="<%= value || node.title %>"<%= (node.disabled? " disabled" : "")%>/>'
   },
   'button':{
-    'template':' <button <% if (id) { %> id="<%= id %>" <% } %> class="<%= cls.buttonClass %> <%= elt.htmlClass?elt.htmlClass:"" %>"><%= node.title %></button> '
+    'template':' <button type="button" <% if (id) { %> id="<%= id %>" <% } %> class="<%= cls.buttonClass %> <%= elt.htmlClass?elt.htmlClass:"" %>"><%= node.title %></button> '
   },
   'actions':{
     'template':'<div class="form-actions <%= elt.htmlClass?elt.htmlClass:"" %>"><%= children %></div>'


### PR DESCRIPTION
If buttons aren't given an explicit type, <form> supplies them with a default 'type="submit"'. The HTML generated for basic buttons didn't have a type, so they were linked to the "onSubmit" function. This made it impossible to create a simple cancel button. 

I added 'type="button"' to the HTML for basic buttons.